### PR TITLE
applepay fix for configurable products / products with options

### DIFF
--- a/src/Mollie_HyvaCompatibility/view/frontend/templates/Mollie_Payment/product/view/applepay.phtml
+++ b/src/Mollie_HyvaCompatibility/view/frontend/templates/Mollie_Payment/product/view/applepay.phtml
@@ -79,6 +79,15 @@ $product = $block->getProduct();
         }
 
         session.onvalidatemerchant = (event) => {
+            const form = document.getElementById('product_addtocart_form'),
+                  formData = new FormData(form),
+                  formDataObject = {};
+            formData.forEach((value, key) => {
+                formDataObject[key] = value;
+            });
+            formDataObject["product"] = <?= (int)$product->getId() ?>;
+            formDataObject["validationURL"] = event.validationURL;
+
             fetch(`${BASE_URL}mollie/applePay/buyNowValidation?form_key=${hyva.getFormKey()}`, {
                 method: 'POST',
                 headers: {


### PR DESCRIPTION
Currently it is not possible to buy a configurable product with apple pay button on product page. The problem is that none of the product options are passed to buyNowValidation actiuon, so the product is not added to cart. That should also fix any product with required options as all the product form params are now passed.