### PR TITLE
Fix the total calculation when the grand total is not the last object…

### DIFF
--- a/src/Mollie_HyvaCompatibility/view/frontend/templates/Mollie_Payment/applepay/minicart/applepay-button.phtml
+++ b/src/Mollie_HyvaCompatibility/view/frontend/templates/Mollie_Payment/applepay/minicart/applepay-button.phtml
@@ -77,8 +77,8 @@ use Magento\Framework\Escaper;
                 let session = new ApplePaySession(3, request);
 
                 const getTotal = () => {
-                    let totals = [...quoteTotals];
-                    let total = totals.pop();
+                    // Find grand_total specifically instead of taking the last item
+                    const total = quoteTotals.find(item => item.code === 'grand_total') || quoteTotals[quoteTotals.length - 1];
 
                     total.label = "<?= $escaper->escapeJs($block->getStoreName()); ?>";
 
@@ -87,9 +87,21 @@ use Magento\Framework\Escaper;
 
                 const getLineItems = () => {
                     let totals = [...quoteTotals];
-                    totals.pop();
 
-                    return totals;
+                    // Remove grand_total from line items
+                    totals = totals.filter(item => item.code !== 'grand_total');
+
+                    // This allows for custom filtering through a global event
+                    const filterEvent = new CustomEvent('mollie-applepay-filter-lineitems', {
+                        detail: { lineItems: totals },
+                        bubbles: true,
+                        cancelable: true
+                    });
+
+                    window.dispatchEvent(filterEvent);
+
+                    // Use the potentially modified line items from the event
+                    return filterEvent.detail.lineItems;
                 };
 
                 const handleAjaxError = (message) => {


### PR DESCRIPTION
# ApplePay Checkout Improvements

## Overview
This PR enhances the ApplePay checkout functionality by:
1. Modifying how line items and totals are handled
2. Adding an extension system for filtering line items
3. Implementing a specific filter for removing specified totals

## Changes
### Core Functionality Updates
- Modified `getTotal()` to specifically find the `grand_total` item instead of relying on array position
- Refactored `getLineItems()` to support custom filtering through a global event system
- Added fallback logic if the `grand_total` item isn't found (i'm not sure that this need)

### New Extension System
- Created a custom event `mollie-applepay-filter-lineitems` that allows external code to modify line items
- Implemented event bubbling to ensure proper propagation
- Added detailed documentation in code comments
