### PR TITLE
Fix deprecated usages of escaper

### DIFF
--- a/src/Mollie_HyvaCompatibility/view/frontend/templates/Mollie_Payment/applepay/minicart/applepay-button.phtml
+++ b/src/Mollie_HyvaCompatibility/view/frontend/templates/Mollie_Payment/applepay/minicart/applepay-button.phtml
@@ -17,7 +17,7 @@ use Magento\Framework\Escaper;
      x-data="prepareMollieApplePayMinicart"
 >
 
-    <div class="<?= $block->escapeHtmlAttr($block->getButtonClasses()); ?> cursor-pointer"
+    <div class="<?= $escaper->escapeHtmlAttr($block->getButtonClasses()); ?> cursor-pointer"
          @click="pay"
     >
         <span class="sr-only">Buy with</span>

--- a/src/Mollie_HyvaCompatibility/view/frontend/templates/Mollie_Payment/applepay/minicart/applepay-button.phtml
+++ b/src/Mollie_HyvaCompatibility/view/frontend/templates/Mollie_Payment/applepay/minicart/applepay-button.phtml
@@ -4,12 +4,11 @@
  * See COPYING.txt for license details.
  */
 
-use Magento\Framework\Escaper;
+ use Magento\Framework\Escaper;
+ use Mollie\Payment\Block\Applepay\Shortcut\Button;
 
-/**
- * @var \Mollie\Payment\Block\Applepay\Shortcut\Button $block
- * @var Escaper $escaper
- */
+ /** @var Escaper $escaper */
+ /** @var Button $block */
 
 ?>
 <div id="mollie_applepay_minicart"

--- a/src/Mollie_HyvaCompatibility/view/frontend/templates/Mollie_Payment/product/view/applepay.phtml
+++ b/src/Mollie_HyvaCompatibility/view/frontend/templates/Mollie_Payment/product/view/applepay.phtml
@@ -32,9 +32,9 @@ $product = $block->getProduct();
 
         return {
             startApplePayPayment() {
-                let currencyCode = "<?= $block->escapeJs($block->getCurrencyCode()); ?>";
-                let countryCode = "<?= $block->escapeJs($block->getCountryCode()); ?>";
-                let storeName = "<?= $block->escapeJs($block->getStoreName()); ?>";
+                let currencyCode = "<?= $escaper->escapeJs($block->getCurrencyCode()); ?>";
+                let countryCode = "<?= $escaper->escapeJs($block->getCountryCode()); ?>";
+                let storeName = "<?= $escaper->escapeJs($block->getStoreName()); ?>";
                 let supportedNetworks = <?= json_encode($block->getSupportedNetworks()); ?>;
 
                 const form = document.getElementById('product_addtocart_form');

--- a/src/Mollie_HyvaCompatibility/view/frontend/templates/Mollie_Payment/product/view/applepay.phtml
+++ b/src/Mollie_HyvaCompatibility/view/frontend/templates/Mollie_Payment/product/view/applepay.phtml
@@ -4,8 +4,11 @@
  * See COPYING.txt for license details.
  */
 
-/** @var \Magento\Framework\Escaper $escaper */
-/** @var \Mollie\Payment\Block\Product\View\ApplePay $block */
+use Magento\Framework\Escaper;
+use Mollie\Payment\Block\Product\View\ApplePay;
+
+/** @var Escaper $escaper */
+/** @var ApplePay $block */
 
 if (!$block->isEnabled()) {
     return;

--- a/src/Mollie_HyvaCompatibility/view/frontend/templates/applepay/minicart/applepay-button-script.phtml
+++ b/src/Mollie_HyvaCompatibility/view/frontend/templates/applepay/minicart/applepay-button-script.phtml
@@ -5,11 +5,10 @@
  */
 
 use Magento\Framework\Escaper;
+use Mollie\Payment\Block\Applepay\Shortcut\Button;
 
-/**
- * @var \Mollie\Payment\Block\Applepay\Shortcut\Button $block
- * @var Escaper $escaper
- */
+/** @var Escaper $escaper */
+/** @var Button $block */
 
 ?>
 <script>

--- a/src/Mollie_HyvaCompatibility/view/frontend/templates/customer/account/subscriptions.phtml
+++ b/src/Mollie_HyvaCompatibility/view/frontend/templates/customer/account/subscriptions.phtml
@@ -6,10 +6,12 @@
 
 use Hyva\Theme\Model\ViewModelRegistry;
 use Hyva\Theme\ViewModel\HeroiconsOutline;
+use Magento\Framework\Escaper;
+use Mollie\Subscriptions\Block\Frontend\Customer\Account\ActiveSubscriptions;
 
-/** @var \Magento\Framework\Escaper $escaper */
-/** @var \Mollie\Subscriptions\Block\Frontend\Customer\Account\ActiveSubscriptions $block */
 /** @var ViewModelRegistry $viewModels */
+/** @var Escaper $escaper */
+/** @var ActiveSubscriptions $block */
 
 /** @var HeroiconsOutline $heroicons */
 $heroicons = $viewModels->require(HeroiconsOutline::class);

--- a/src/Mollie_HyvaCompatibility/view/frontend/templates/product/view/subscription-options.phtml
+++ b/src/Mollie_HyvaCompatibility/view/frontend/templates/product/view/subscription-options.phtml
@@ -6,11 +6,12 @@
 
 use Hyva\Theme\Model\ViewModelRegistry;
 use Hyva\Theme\ViewModel\HeroiconsOutline;
-
-/** @var \Mollie\Subscriptions\Block\Frontend\Product\View\SubscriptionOptions $block */
-/** @var \Magento\Framework\Escaper $escaper */
+use Magento\Framework\Escaper;
+use Mollie\Subscriptions\Block\Frontend\Product\View\SubscriptionOptions;
 
 /** @var ViewModelRegistry $viewModels */
+/** @var Escaper $escaper */
+/** @var SubscriptionOptions $block */
 
 /** @var HeroiconsOutline $heroicons */
 $heroicons = $viewModels->require(HeroiconsOutline::class);


### PR DESCRIPTION
This PR corrects the usage of `$block->escapeHtml()` in several templates, replacing it with the recommended `$escaper->escapeHtml()` method.

Additionally, I have standardized the PHP file headers. They were previously inconsistent and have now been updated to align with Hyvä and Magento 2 industry standards.